### PR TITLE
Updated Twitter share button

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -25,6 +25,17 @@
       {{.Content}}
       </article>
 
+      <div>
+        <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" 
+        class="twitter-share-button"
+        data-size="large" 
+        data-via="exegeticdata" 
+        data-text="{{ .Params.title }}"
+        data-hashtags="{{ delimit .Params.tags "," }}"
+        data-show-count="false">Tweet</a>
+        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+      </div>
+
       <aside>
         <div class="row">
           <div class="col-md-6">
@@ -39,6 +50,7 @@
           </div>
         </div>
       </aside>
+      
     </div>
   </section>
 {{ end }}


### PR DESCRIPTION
The button will only include the relevant post's title and not the site's title.